### PR TITLE
fix: update extraction to use new path to overwrite ollama.exe for lib injection

### DIFF
--- a/ollama_installer.py
+++ b/ollama_installer.py
@@ -603,11 +603,17 @@ class OllamaInstallerGUI:
 
             self.kill_ollama()
             self.log_msg("Extracting framework...")
-            if os.path.exists(rocm_lib_dir):
-                shutil.rmtree(rocm_lib_dir, ignore_errors=True)
-            os.makedirs(rocm_lib_dir, exist_ok=True)
+            
+            temp_fw_dir = tempfile.mkdtemp()
             with py7zr.SevenZipFile(base_archive, 'r') as archive:
-                archive.extractall(path=rocm_lib_dir)
+                archive.extractall(path=temp_fw_dir)
+                
+            fw_extracted_root = os.path.join(temp_fw_dir, "windows-amd64")
+            if not os.path.exists(fw_extracted_root):
+                fw_extracted_root = temp_fw_dir
+                
+            shutil.copytree(fw_extracted_root, ollama_path, dirs_exist_ok=True)
+            shutil.rmtree(temp_fw_dir, ignore_errors=True)
 
             gpu_url = get_rocm_url(gpu_model)
             if not gpu_url:


### PR DESCRIPTION
### Problem
My Ollama was falling back to CPU runner, which was weird because exact HIP SDK 6.4.2 was working on old builds of the project's installer. After a bit of digging, found out the culprit was the custom ollama 7z `ollama-windows-amd64.7z`.

### Changes In New Structure
The new `ollama-windows-amd64.7z` archive uses `windows-amd64/` subfolder while the old one didn't nest into this new folder. The current extraction logic works in AppData directly which doesn't actually overwrite the original exe, just puts in different folder. (This was why my Ollama was falling back to CPU runner).

Patched the replace logic to account for new nested dir. And everything works fine now.